### PR TITLE
app-ruby: change newlib dependency to musl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+UK_ROOT ?= $(PWD)/.unikraft/unikraft
+UK_LIBS ?= $(PWD)/.unikraft/libs
+LIBS := $(UK_LIBS)/musl:$(UK_LIBS)/libunwind:$(UK_LIBS)/compiler-rt:$(UK_LIBS)/libcxx:$(UK_LIBS)/lwip:$(UK_LIBS)/ruby
+
+all:
+	@$(MAKE) -C $(UK_ROOT) A=$(PWD) L=$(LIBS)
+
+$(MAKECMDGOALS):
+	@$(MAKE) -C $(UK_ROOT) A=$(PWD) L=$(LIBS) $(MAKECMDGOALS)

--- a/Makefile.uk
+++ b/Makefile.uk
@@ -1,0 +1,1 @@
+$(eval $(call addlib,appruby))

--- a/kraft.yaml
+++ b/kraft.yaml
@@ -25,7 +25,6 @@ targets:
   - architecture: x86_64
     platform: kvm
 libraries:
-  pthread-embedded: '0.5'
   libunwind: '0.5'
   compiler-rt: '0.5'
   libcxx:
@@ -34,10 +33,8 @@ libraries:
       - CONFIG_LIBCXX=y
       - CONFIG_CXX_THREADS=y
   libcxxabi: '0.5'
-  newlib:
-    version: '0.5'
-    kconfig:
-      - CONFIG_LIBNEWLIBC=y
+  libmusl:
+    version: 'stable'
   lwip:
     version: '0.5'
     kconfig:


### PR DESCRIPTION
This PR fixes https://github.com/unikraft/app-ruby/issues/3, by changing newlib dependency to musl. It also add Makefile and Makefile.uk for manual building.